### PR TITLE
Implement minimal ExploreQuiz app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore node_modules if using node packages later
+node_modules/
+# Ignore logs
+*.log
+# MacOS system files
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Beitragshinweise
+
+Bitte verwende prägnante Commit-Botschaften und beschreibe in kurzen Sätzen, welche Änderungen vorgenommen wurden. Mehrere zusammenhängende Änderungen sollten in separaten Commits festgehalten werden.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ExploreQuiz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# ExploreQuiz: Reise um die Welt
+
+Dies ist eine einfache Quiz-Anwendung rund um Länder, Kulturen und Sehenswürdigkeiten. Alle Daten werden lokal gespeichert, sodass die App auch offline funktioniert.
+
+## Funktionen
+- **Quiz-Modus:** Multiple-Choice-Fragen mit Kategorieauswahl oder Zufallsmodus
+- **Level- & Punktesystem:** +10 Punkte pro richtiger Antwort, neues Level alle 100 Punkte
+- **Spielerprofil:** Benutzername und Punktestand werden im Browser gespeichert
+
+## Nutzung
+1. Repository klonen oder herunterladen
+2. `index.html` im Browser öffnen – es ist keine weitere Installation notwendig
+3. Beim ersten Start Benutzernamen eingeben und mit dem Spielen beginnen
+
+## Datenstruktur
+Die Fragen befinden sich in `data/questions.json` im folgenden Format:
+```json
+{
+  "fragen": [
+    {
+      "frage": "Was ist die Hauptstadt von Japan?",
+      "optionen": ["Kyoto", "Osaka", "Tokio", "Hiroshima"],
+      "antwort": "Tokio",
+      "kategorie": "Japan"
+    }
+  ]
+}
+```
+
+## Lizenz
+Dieser Code steht unter der MIT-Lizenz. Siehe [LICENSE](LICENSE) für Details.

--- a/data/questions.json
+++ b/data/questions.json
@@ -1,0 +1,16 @@
+{
+  "fragen": [
+    {
+      "frage": "Was ist die Hauptstadt von Japan?",
+      "optionen": ["Kyoto", "Osaka", "Tokio", "Hiroshima"],
+      "antwort": "Tokio",
+      "kategorie": "Japan"
+    },
+    {
+      "frage": "Welches Land gehört NICHT zu Skandinavien?",
+      "optionen": ["Norwegen", "Finnland", "Dänemark", "Island"],
+      "antwort": "Finnland",
+      "kategorie": "Europa"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>ExploreQuiz: Reise um die Welt</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>ExploreQuiz</h1>
+    <div id="score"></div>
+    <nav>
+      <button id="startBtn">Spielen</button>
+      <button id="profileBtn">Mein Profil</button>
+      <select id="categorySelect">
+        <option value="all">Alle Kategorien</option>
+        <option value="Japan">Japan</option>
+        <option value="Europa">Europa</option>
+      </select>
+    </nav>
+  </header>
+  <main>
+    <section id="quiz">
+      <div id="question">Lade Frage...</div>
+      <div id="answers">
+        <button></button>
+        <button></button>
+        <button></button>
+        <button></button>
+      </div>
+    </section>
+    <section id="profile" class="hidden">
+      <h2>Mein Profil</h2>
+      <p>Benutzer: <span id="username"></span></p>
+    </section>
+  </main>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,71 @@
+let questions = [];
+let currentQuestionIndex = 0;
+let score = parseInt(localStorage.getItem('score')) || 0;
+let username = localStorage.getItem('username') || '';
+let currentCategory = 'all';
+
+async function loadQuestions() {
+  const response = await fetch('data/questions.json');
+  const data = await response.json();
+  questions = data.fragen;
+}
+
+function showQuestion() {
+  const filtered = currentCategory === 'all'
+    ? questions
+    : questions.filter(q => q.kategorie === currentCategory);
+  if (filtered.length === 0) return;
+  currentQuestionIndex = currentQuestionIndex % filtered.length;
+  const q = filtered[currentQuestionIndex];
+  document.getElementById('question').textContent = q.frage;
+  const buttons = document.querySelectorAll('#answers button');
+  buttons.forEach((btn, idx) => {
+    btn.textContent = q.optionen[idx];
+    btn.onclick = () => checkAnswer(q.optionen[idx]);
+  });
+  updateScore();
+}
+
+function checkAnswer(answer) {
+  const filtered = currentCategory === 'all'
+    ? questions
+    : questions.filter(q => q.kategorie === currentCategory);
+  const q = filtered[currentQuestionIndex];
+  if (answer === q.antwort) {
+    score += 10;
+    localStorage.setItem('score', score);
+  }
+  currentQuestionIndex = (currentQuestionIndex + 1) % filtered.length;
+  showQuestion();
+}
+
+function updateScore() {
+  const level = Math.floor(score / 100) + 1;
+  document.getElementById('score').textContent = `Punkte: ${score} | Level: ${level}`;
+}
+
+function initProfile() {
+  if (!username) {
+    username = prompt('Bitte Benutzernamen eingeben:');
+    localStorage.setItem('username', username);
+  }
+  document.getElementById('username').textContent = username;
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  initProfile();
+  await loadQuestions();
+  showQuestion();
+  document.getElementById('profileBtn').addEventListener('click', () => {
+    document.getElementById('profile').classList.toggle('hidden');
+  });
+  document.getElementById('startBtn').addEventListener('click', () => {
+    document.getElementById('profile').classList.add('hidden');
+    showQuestion();
+  });
+  document.getElementById('categorySelect').addEventListener('change', e => {
+    currentCategory = e.target.value;
+    currentQuestionIndex = 0;
+    showQuestion();
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,29 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f4f4f4;
+}
+header {
+  background: #0066cc;
+  color: #fff;
+  padding: 10px;
+  text-align: center;
+}
+main {
+  padding: 20px;
+}
+button {
+  margin: 5px;
+  padding: 10px 20px;
+}
+.hidden {
+  display: none;
+}
+#question {
+  font-size: 1.2em;
+  margin-bottom: 20px;
+}
+#profile {
+  margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- add project README and contribution guide
- create MIT license and gitignore
- implement HTML structure with navigation
- load questions from local JSON and handle categories
- store progress in localStorage
- add basic styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68515ef3aea0832da4d7f8860fd88520